### PR TITLE
Statefull foldable sidemenu

### DIFF
--- a/src/components/navigations/MenuItem.tsx
+++ b/src/components/navigations/MenuItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
+import { safeLocalStorage, slugify } from "../utils/storage";
 
 export type AsindeMenuSingleItemProps = {
     link?: string;
@@ -18,46 +19,52 @@ export type AsidemenuItemsProps = {
 
 const SIDE_MENU_FOLD_STATE_ITEM = "asidemenu-fold-state";
 
-const slugify = (text: string) => {
-    return text
-        .toString()
-        .toLowerCase()
-        .trim()
-        .replace(/\s+/g, "-") // Replace spaces with -  
+const getKey = (heading: React.ReactNode, alias: string): string => {
+    const identifier = typeof heading === "string" ? slugify(heading) : alias;
+
+    if (!identifier) {
+        console.warn('MenuItem: Neither string heading nor alias provided. Using fallback key.');
+        return `asidemenu-fallback-${Date.now()}-open`;
+    }
+
+    return `asidemenu-${identifier}-open`;
 }
 
-const getKey = (heading: React.ReactNode, key: number | string) => {
-    return `asidemenu-${typeof heading === "string" ? slugify(heading) : slugify(key.toString())}-open`;
-}
-
-const getFoldState = (heading: React.ReactNode, key: number | string) => {
-    const storedState = localStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
-    if (storedState) {
-        const foldState = JSON.parse(storedState);
-        return foldState[getKey(heading, key)] === true;
+const getFoldState = (heading: React.ReactNode, alias: string): boolean => {
+    try {
+        const storedState = safeLocalStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
+        if (storedState) {
+            const foldState = JSON.parse(storedState);
+            return foldState[getKey(heading, alias)] === true;
+        }
+    } catch (error) {
+        console.error('Failed to parse fold state from localStorage:', error);
     }
     return false; // Default to closed if no state is stored
 }
 
-const setFoldState = (heading: React.ReactNode, key: number | string, isOpen: boolean) => {
-    const storedState = localStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
-    const foldState = storedState ? JSON.parse(storedState) : {};
-    foldState[getKey(heading, key)] = isOpen;
-    localStorage.setItem(SIDE_MENU_FOLD_STATE_ITEM, JSON.stringify(foldState));
+const setFoldState = (heading: React.ReactNode, alias: string, isOpen: boolean): void => {
+    try {
+        const storedState = safeLocalStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
+        const foldState = storedState ? JSON.parse(storedState) : {};
+        foldState[getKey(heading, alias)] = isOpen;
+        safeLocalStorage.setItem(SIDE_MENU_FOLD_STATE_ITEM, JSON.stringify(foldState));
+    } catch (error) {
+        console.error('Failed to save fold state to localStorage:', error);
+    }
 }
 
 const MenuItem = ({ alias, heading, menus, submenus, useReactRouterLinks, foldable = false }: AsidemenuItemsProps) => {
 
 
-
     const [isOpen, setIsOpen] = useState(
-        foldable ? getFoldState(heading, alias || "") : true
+        foldable ? getFoldState(heading, alias) : true
     );
 
     const toggleOpen = () => {
         if (!foldable) return;
         const newOpenState = !isOpen;
-        setFoldState(heading, alias || "", newOpenState);
+        setFoldState(heading, alias, newOpenState);
         setIsOpen(!isOpen);
     };
 

--- a/src/components/navigations/MenuItem.tsx
+++ b/src/components/navigations/MenuItem.tsx
@@ -65,7 +65,7 @@ const MenuItem = ({ alias, heading, menus, submenus, useReactRouterLinks, foldab
         if (!foldable) return;
         const newOpenState = !isOpen;
         setFoldState(heading, alias, newOpenState);
-        setIsOpen(!isOpen);
+        setIsOpen(newOpenState);
     };
 
     const chevronStyle = {

--- a/src/components/navigations/MenuItem.tsx
+++ b/src/components/navigations/MenuItem.tsx
@@ -2,26 +2,62 @@ import { useState } from "react";
 import { ChevronDown, ChevronRight } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
 
-
 export type AsindeMenuSingleItemProps = {
     link?: string;
-    anchor?: string;
+    anchor?: React.ReactNode;
 };
 
 export type AsidemenuItemsProps = {
     heading?: React.ReactNode;
+    alias?: string; // Optional alias for localStorage key generation if heading is not a string
     menus?: Array<AsindeMenuSingleItemProps>;
     submenus?: Array<AsidemenuItemsProps>;
     useReactRouterLinks?: boolean;
     foldable?: boolean;
 };
 
+const SIDE_MENU_FOLD_STATE_ITEM = "asidemenu-fold-state";
 
-const MenuItem = ({ heading, menus, submenus, useReactRouterLinks, foldable = false }: AsidemenuItemsProps) => {
-    const [isOpen, setIsOpen] = useState(true);
+const slugify = (text: string) => {
+    return text
+        .toString()
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, "-") // Replace spaces with -  
+}
+
+const getKey = (heading: React.ReactNode, key: number | string) => {
+    return `asidemenu-${typeof heading === "string" ? slugify(heading) : slugify(key.toString())}-open`;
+}
+
+const getFoldState = (heading: React.ReactNode, key: number | string) => {
+    const storedState = localStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
+    if (storedState) {
+        const foldState = JSON.parse(storedState);
+        return foldState[getKey(heading, key)] === true;
+    }
+    return false; // Default to closed if no state is stored
+}
+
+const setFoldState = (heading: React.ReactNode, key: number | string, isOpen: boolean) => {
+    const storedState = localStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
+    const foldState = storedState ? JSON.parse(storedState) : {};
+    foldState[getKey(heading, key)] = isOpen;
+    localStorage.setItem(SIDE_MENU_FOLD_STATE_ITEM, JSON.stringify(foldState));
+}
+
+const MenuItem = ({ alias, heading, menus, submenus, useReactRouterLinks, foldable = false }: AsidemenuItemsProps) => {
+
+
+
+    const [isOpen, setIsOpen] = useState(
+        foldable ? getFoldState(heading, alias || "") : true
+    );
 
     const toggleOpen = () => {
         if (!foldable) return;
+        const newOpenState = !isOpen;
+        setFoldState(heading, alias || "", newOpenState);
         setIsOpen(!isOpen);
     };
 

--- a/src/components/navigations/MenuItem.tsx
+++ b/src/components/navigations/MenuItem.tsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
 import { ChevronDown, ChevronRight } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
-import { safeLocalStorage, slugify } from "../utils/storage";
+import { useFoldState } from "../utils/storage";
 
 export type AsindeMenuSingleItemProps = {
     link?: string;
@@ -17,56 +16,8 @@ export type AsidemenuItemsProps = {
     foldable?: boolean;
 };
 
-const SIDE_MENU_FOLD_STATE_ITEM = "asidemenu-fold-state";
-
-const getKey = (heading: React.ReactNode, alias: string): string => {
-    const identifier = typeof heading === "string" ? slugify(heading) : alias;
-
-    if (!identifier) {
-        console.warn('MenuItem: Neither string heading nor alias provided. Using fallback key.');
-        return `asidemenu-fallback-${Date.now()}-open`;
-    }
-
-    return `asidemenu-${identifier}-open`;
-}
-
-const getFoldState = (heading: React.ReactNode, alias: string): boolean => {
-    try {
-        const storedState = safeLocalStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
-        if (storedState) {
-            const foldState = JSON.parse(storedState);
-            return foldState[getKey(heading, alias)] === true;
-        }
-    } catch (error) {
-        console.error('Failed to parse fold state from localStorage:', error);
-    }
-    return false; // Default to closed if no state is stored
-}
-
-const setFoldState = (heading: React.ReactNode, alias: string, isOpen: boolean): void => {
-    try {
-        const storedState = safeLocalStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
-        const foldState = storedState ? JSON.parse(storedState) : {};
-        foldState[getKey(heading, alias)] = isOpen;
-        safeLocalStorage.setItem(SIDE_MENU_FOLD_STATE_ITEM, JSON.stringify(foldState));
-    } catch (error) {
-        console.error('Failed to save fold state to localStorage:', error);
-    }
-}
-
 const MenuItem = ({ alias, heading, menus, submenus, useReactRouterLinks, foldable = false }: AsidemenuItemsProps) => {
-
-
-    const [isOpen, setIsOpen] = useState(
-        foldable ? getFoldState(heading, alias) : true
-    );
-
-    const toggleOpen = () => {
-        if (!foldable) return;
-        const newOpenState = !isOpen;
-        setFoldState(heading, alias, newOpenState);
-        setIsOpen(newOpenState);
-    };
+    const { isOpen, toggle } = useFoldState(heading, alias, foldable);
 
     const chevronStyle = {
         marginTop: "-2px",
@@ -76,7 +27,7 @@ const MenuItem = ({ alias, heading, menus, submenus, useReactRouterLinks, foldab
     return (
         <li>
             {foldable ? (
-                <a onClick={toggleOpen}>
+                <a onClick={toggle}>
                     {isOpen ? <ChevronDown style={chevronStyle} /> : <ChevronRight style={chevronStyle} />} {heading}
                 </a>
             ) : (

--- a/src/components/navigations/asidemenu.tsx
+++ b/src/components/navigations/asidemenu.tsx
@@ -30,9 +30,7 @@ export function Asidemenu({
     return (menuItems || []).map((item, i) => (
       <MenuItem
         key={i}
-        heading={item.heading}
-        menus={item.menus}
-        submenus={item.submenus}
+        {...item}
         foldable={foldable}
         useReactRouterLinks={useReactRouterLinks}
       />

--- a/src/components/utils/storage.ts
+++ b/src/components/utils/storage.ts
@@ -35,3 +35,72 @@ export const slugify = (text: string): string => {
         .replace(/-+/g, '-') // Remove duplicate hyphens
         .replace(/^-+|-+$/g, ''); // Trim hyphens from start/end
 };
+
+/**
+ * Manages fold state persistence in localStorage for menu items
+ */
+import { useState } from 'react';
+
+const SIDE_MENU_FOLD_STATE_ITEM = "asidemenu-fold-state";
+
+const generateKey = (heading: React.ReactNode, alias?: string): string => {
+    const identifier = typeof heading === "string" ? slugify(heading) : alias;
+
+    if (!identifier) {
+        console.warn('MenuItem: Neither string heading nor alias provided. Using fallback key.');
+        return `asidemenu-fallback-${Date.now()}-open`;
+    }
+
+    return `asidemenu-${identifier}-open`;
+};
+
+const getFoldState = (key: string): boolean => {
+    try {
+        const storedState = safeLocalStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
+        if (storedState) {
+            const foldState = JSON.parse(storedState);
+            return foldState[key] === true;
+        }
+    } catch (error) {
+        console.error('Failed to parse fold state from localStorage:', error);
+    }
+    return false; // Default to closed if no state is stored
+};
+
+const setFoldState = (key: string, isOpen: boolean): void => {
+    try {
+        const storedState = safeLocalStorage.getItem(SIDE_MENU_FOLD_STATE_ITEM);
+        const foldState = storedState ? JSON.parse(storedState) : {};
+        foldState[key] = isOpen;
+        safeLocalStorage.setItem(SIDE_MENU_FOLD_STATE_ITEM, JSON.stringify(foldState));
+    } catch (error) {
+        console.error('Failed to save fold state to localStorage:', error);
+    }
+};
+
+/**
+ * Custom hook to manage foldable menu state with localStorage persistence
+ * 
+ * We still need React state because:
+ * - Changing localStorage alone doesn't trigger re-renders
+ * - React needs to know when the component should update
+ * - State provides the reactive behavior expected in React components
+ * 
+ * This hook abstracts away the localStorage logic from the component
+ */
+export const useFoldState = (heading: React.ReactNode, alias?: string, foldable: boolean = false) => {
+    const key = generateKey(heading, alias);
+    const initialState = foldable ? getFoldState(key) : true;
+
+    const [isOpen, setIsOpen] = useState(initialState);
+
+    const toggle = () => {
+        if (!foldable) return;
+
+        const newState = !isOpen;
+        setIsOpen(newState);
+        setFoldState(key, newState);
+    };
+
+    return { isOpen, toggle };
+};

--- a/src/components/utils/storage.ts
+++ b/src/components/utils/storage.ts
@@ -1,0 +1,37 @@
+/**
+ * Safe wrapper around localStorage to handle errors gracefully
+ */
+export const safeLocalStorage = {
+    getItem: (key: string): string | null => {
+        try {
+            return localStorage.getItem(key);
+        } catch (error) {
+            console.warn(`Failed to read from localStorage: ${error}`);
+            return null;
+        }
+    },
+
+    setItem: (key: string, value: string): void => {
+        try {
+            localStorage.setItem(key, value);
+        } catch (error) {
+            console.warn(`Failed to write to localStorage: ${error}`);
+        }
+    }
+};
+
+/**
+ * Robust slugification function that handles special characters and diacritics
+ */
+export const slugify = (text: string): string => {
+    return text
+        .toString()
+        .toLowerCase()
+        .normalize('NFD') // Decompose accented characters
+        .replace(/[\u0300-\u036f]/g, '') // Remove diacritics
+        .trim()
+        .replace(/[^\w\s-]/g, '') // Remove special characters
+        .replace(/\s+/g, '-') // Replace spaces with hyphens
+        .replace(/-+/g, '-') // Remove duplicate hyphens
+        .replace(/^-+|-+$/g, ''); // Trim hyphens from start/end
+};

--- a/src/stories/base.stories.tsx
+++ b/src/stories/base.stories.tsx
@@ -110,6 +110,7 @@ export const WithFoldableLinks: Story = {
       }, {
         useReactRouterLinks: true,
         heading: <>Second menu <span className="badge badge-danger">NEW</span></>,
+        alias: "second-menu",
         menus: [
           { anchor: "Hi!", link: "/" },
           { anchor: "HelloTabs", link: "/hellotabs" },

--- a/src/stories/base.stories.tsx
+++ b/src/stories/base.stories.tsx
@@ -107,9 +107,9 @@ export const WithFoldableLinks: Story = {
           { anchor: "HelloTabs", link: "/hellotabs" },
           { anchor: "HelloVisualizations", link: "/hellovisualizations" },
         ],
-      },{
+      }, {
         useReactRouterLinks: true,
-        heading: "Second menu",
+        heading: <>Second menu <span className="badge badge-danger">NEW</span></>,
         menus: [
           { anchor: "Hi!", link: "/" },
           { anchor: "HelloTabs", link: "/hellotabs" },


### PR DESCRIPTION
- Added side menut state persistance via local storage
- Relaxed typing on side menu items to allow badges, counter, icons etc. (type ReactNode)
- Updated example